### PR TITLE
[Sdf] Remove some boost usage

### DIFF
--- a/pxr/usd/sdf/namespaceEdit.cpp
+++ b/pxr/usd/sdf/namespaceEdit.cpp
@@ -662,6 +662,12 @@ SdfNamespaceEdit::operator==(const SdfNamespaceEdit& rhs) const
            index       == rhs.index;
 }
 
+bool
+SdfNamespaceEdit::operator!=(const This& rhs) const
+{
+    return !(*this == rhs);
+}
+
 std::ostream&
 operator<<(std::ostream& s, const SdfNamespaceEdit& x)
 {
@@ -710,6 +716,12 @@ SdfNamespaceEditDetail::operator==(const SdfNamespaceEditDetail& rhs) const
     return result == rhs.result  && 
            edit   == rhs.edit    &&
            reason == rhs.reason;
+}
+
+bool
+SdfNamespaceEditDetail::operator!=(const SdfNamespaceEditDetail& rhs) const
+{
+    return !(*this == rhs);
 }
 
 std::ostream&

--- a/pxr/usd/sdf/namespaceEdit.h
+++ b/pxr/usd/sdf/namespaceEdit.h
@@ -30,8 +30,6 @@
 #include "pxr/usd/sdf/api.h"
 #include "pxr/usd/sdf/path.h"
 
-#include <boost/operators.hpp>
-
 #include <functional>
 #include <iosfwd>
 #include <string>
@@ -44,8 +42,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// A single namespace edit.  It supports renaming, reparenting, reparenting
 /// with a rename, reordering, and removal.
 ///
-struct SdfNamespaceEdit :
-    boost::equality_comparable<SdfNamespaceEdit> {
+struct SdfNamespaceEdit {
 public:
     typedef SdfNamespaceEdit This;
     typedef SdfPath Path;
@@ -114,6 +111,7 @@ public:
     }
 
     SDF_API bool operator==(const This& rhs) const;
+    SDF_API bool operator!=(const This& rhs) const;
 
 public:
     Path currentPath;   ///< Path of the object when this edit starts.
@@ -131,8 +129,7 @@ SDF_API std::ostream& operator<<(std::ostream&, const SdfNamespaceEditVector&);
 ///
 /// Detailed information about a namespace edit.
 ///
-struct SdfNamespaceEditDetail :
-    boost::equality_comparable<SdfNamespaceEditDetail> {
+struct SdfNamespaceEditDetail {
 public:
     /// Validity of an edit.
     enum Result {
@@ -146,6 +143,7 @@ public:
                            const std::string& reason);
 
     SDF_API bool operator==(const SdfNamespaceEditDetail& rhs) const;
+    SDF_API bool operator!=(const SdfNamespaceEditDetail& rhs) const;
 
 public:
     Result result;          ///< Validity.

--- a/pxr/usd/sdf/types.cpp
+++ b/pxr/usd/sdf/types.cpp
@@ -400,6 +400,11 @@ bool SdfUnregisteredValue::operator==(const SdfUnregisteredValue &other) const
     return _value == other._value;
 }
 
+bool SdfUnregisteredValue::operator!=(const SdfUnregisteredValue &other) const
+{
+    return _value != other._value;
+}
+
 std::ostream &operator << (std::ostream &out, const SdfUnregisteredValue &value)
 {
     return out << value.GetValue();

--- a/pxr/usd/sdf/types.h
+++ b/pxr/usd/sdf/types.h
@@ -438,8 +438,7 @@ std::ostream &VtStreamOut(const SdfVariantSelectionMap &, std::ostream &);
 /// well as limited inspection and editing capabilities (e.g., moving
 /// this data to a different spec or field) even when the data type
 /// of the value isn't known.
-class SdfUnregisteredValue : 
-    public boost::equality_comparable<SdfUnregisteredValue>
+class SdfUnregisteredValue
 {
 public:
     /// Wraps an empty VtValue
@@ -466,6 +465,9 @@ public:
 
     /// Returns true if the wrapped VtValues are equal
     SDF_API bool operator==(const SdfUnregisteredValue &other) const;
+
+    /// Returns true if the wrapped VtValues are not equal
+    SDF_API bool operator!=(const SdfUnregisteredValue &other) const;
 
 private:
     VtValue _value;

--- a/pxr/usd/sdf/valueTypeName.cpp
+++ b/pxr/usd/sdf/valueTypeName.cpp
@@ -67,6 +67,11 @@ SdfTupleDimensions::operator==(const SdfTupleDimensions& rhs) const
     return true;
 }
 
+bool
+SdfTupleDimensions::operator!=(const SdfTupleDimensions& rhs) const
+{
+    return !(*this == rhs);
+}
 
 //
 // SdfValueTypeName
@@ -192,6 +197,41 @@ std::vector<TfToken>
 SdfValueTypeName::GetAliasesAsTokens() const
 {
     return _impl->type->aliases;
+}
+
+bool operator!=(const SdfValueTypeName& a, const SdfValueTypeName& b)
+{
+    return !(a == b);
+}
+
+bool operator==(const std::string& a, const SdfValueTypeName& b)
+{
+    return b == a;
+}
+
+bool operator!=(const std::string& a, const SdfValueTypeName& b)
+{
+    return !(a == b);
+}
+
+bool operator!=(const SdfValueTypeName& a, const std::string& b)
+{
+    return !(a == b);
+}
+
+bool operator==(const TfToken& a, const SdfValueTypeName& b)
+{
+    return b == a;
+}
+
+bool operator!=(const TfToken& a, const SdfValueTypeName& b)
+{
+    return !(a == b);
+}
+
+bool operator!=(const SdfValueTypeName& a, const TfToken& b)
+{
+    return !(a == b);
 }
 
 std::ostream&

--- a/pxr/usd/sdf/valueTypeName.h
+++ b/pxr/usd/sdf/valueTypeName.h
@@ -27,7 +27,6 @@
 #include "pxr/pxr.h"
 #include "pxr/usd/sdf/api.h"
 #include "pxr/base/tf/token.h"
-#include <boost/operators.hpp>
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -43,8 +42,7 @@ class Sdf_ValueTypeImpl;
 ///
 /// Represents the shape of a value type (or that of an element in an array).
 ///
-struct SdfTupleDimensions 
-    : boost::equality_comparable<SdfTupleDimensions> {
+struct SdfTupleDimensions {
 public:
     SdfTupleDimensions() : size(0) {}
     SdfTupleDimensions(size_t m) : size(1) { d[0] = m; }
@@ -53,6 +51,7 @@ public:
         : size(2) { d[0] = s[0]; d[1] = s[1]; }
 
     bool operator==(const SdfTupleDimensions& rhs) const;
+    bool operator!=(const SdfTupleDimensions& rhs) const;
 
 public:
     size_t d[2];
@@ -80,11 +79,7 @@ public:
 /// \c SdfSchemaBase::FindType() and shouldn't otherwise need the string.
 /// Aliases compare equal, even if registered by different schemas.
 /// 
-class SdfValueTypeName
-    : boost::equality_comparable<SdfValueTypeName, std::string
-    , boost::equality_comparable<SdfValueTypeName, TfToken
-    , boost::equality_comparable<SdfValueTypeName
-    > > > {
+class SdfValueTypeName {
 public:
     /// Constructs an invalid type name.
     SDF_API
@@ -202,6 +197,17 @@ hash_value(const SdfValueTypeName& typeName)
 {
     return typeName.GetHash();
 }
+
+/// Operators for equality comparisons
+/// @{
+SDF_API bool operator!=(const SdfValueTypeName& a, const SdfValueTypeName& b);
+SDF_API bool operator==(const std::string& a, const SdfValueTypeName& b);
+SDF_API bool operator!=(const std::string& a, const SdfValueTypeName& b);
+SDF_API bool operator!=(const SdfValueTypeName& a, const std::string& b);
+SDF_API bool operator==(const TfToken& a, const SdfValueTypeName& b);
+SDF_API bool operator!=(const TfToken& a, const SdfValueTypeName& b);
+SDF_API bool operator!=(const SdfValueTypeName& a, const TfToken& b);
+/// @}
 
 SDF_API std::ostream& operator<<(std::ostream&, const SdfValueTypeName& typeName);
 


### PR DESCRIPTION
Removes boost::equality_comparable from one library. Also removed a use of boost::optional